### PR TITLE
Bump checkstyle version to 8.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
   - openjdk8
   - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
         <checkstyle.base.rev>HEAD~</checkstyle.base.rev>
         <jgit.version>4.4.1.201607150455-r</jgit.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <checkstyle.version>8.14</checkstyle.version>
+        <checkstyle.version>8.22</checkstyle.version>
+        <cli.version>1.4</cli.version>
         <lombok.version>1.18.2</lombok.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
@@ -167,6 +168,11 @@
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
             <version>${checkstyle.version}</version>
+        </dependency>
+	<dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+	    <version>${cli.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bump checkstyle version from 8.14 to 8.22.

There are many bug fixes, and new features added to checkstyle after version 8.14(https://checkstyle.org/releasenotes.html#Release_8.22). Maybe bumping checkstyle version to 8.22 will help user gain more power from checkstyle.